### PR TITLE
main.mac Pfad in file_search_maxima

### DIFF
--- a/main.mac
+++ b/main.mac
@@ -1,1 +1,6 @@
-load("tuwas.mac");
+/* add directory of this file to search path */
+file_search_maxima: cons(
+	concat(pathname_directory(load_pathname), "###.mac"),
+	file_search_maxima
+);
+load("tuwas.mac")$


### PR DESCRIPTION
Wenn man main.mac aus einem anderen Verzeichnis laedt, funktioniert `load(datei)` nicht mehr. Daher muss das aktuelle Verzeichnis von `main.mac` zu `file_search_maxima` hinzugefuegt werden.